### PR TITLE
依存配列の削除でログが繰り返し出力する問題解消

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -45,18 +45,16 @@ const IndexPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    // API から写真を取得して、PhotoContext のステートを更新する
     const fetchPhotos = async () => {
       if (typeof window !== "undefined") {
-        // 追加
         const fetchedPhotos = await getPhotos({ all_users: true });
+        console.log("Fetched all photos:", fetchedPhotos);
         setAllPhotos(fetchedPhotos);
       }
     };
 
-    // ここでuserがnullでないことを確認
     fetchPhotos();
-  }, [setAllPhotos]); // 依存配列に setAllPhotos を追加
+  }, []); // 依存配列を空に
 
   return (
     <div className="flex flex-col min-h-screen">

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -33,6 +33,7 @@ export async function getPhotos({
 }): Promise<Photo[]> {
   let url = `${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/v1/photos`;
 
+  // パラメータがセットされている場合のみURLに追加
   if (firebase_uid) {
     url += `?firebase_uid=${firebase_uid}`;
   } else if (all_users) {
@@ -44,7 +45,12 @@ export async function getPhotos({
   if (!response.ok) {
     throw new Error("Failed to fetch photos");
   }
-  return await response.json();
+
+  // データをロギング
+  const data = await response.json();
+  console.log("Fetched data:", data);
+
+  return data;
 }
 
 export async function getPhotoById(


### PR DESCRIPTION
index.tsxのuseEffect内でgetPhotos関数を実行している箇所において、
依存配列を設定しており、配列の変更のたびにgetPhotos関数が実行されていた。
依存配列を削除して解消